### PR TITLE
Step3

### DIFF
--- a/Lecture.http
+++ b/Lecture.http
@@ -26,3 +26,8 @@ Content-Type: application/json
 ### 강의 조회 API
 GET http://localhost:8080/lecture/history/2
 Accept: application/json
+
+
+### 신청 가능한 강의 목록 조회 API
+GET http://localhost:8080/lecture/available
+Accept: application/json

--- a/Lecture.http
+++ b/Lecture.http
@@ -1,0 +1,13 @@
+### 강의 등록 API
+POST http://localhost:8080/lecture
+Content-Type: application/json
+
+{
+  "lectureName": "클린아키텍쳐",
+  "memberId": 1,
+  "memberName": "mangKyu",
+  "lectureId": 1,
+  "capacity": 30,
+  "openDate": "2024-10-30",
+  "isClose": false
+}

--- a/Lecture.http
+++ b/Lecture.http
@@ -12,6 +12,17 @@ Content-Type: application/json
   "isClose": false
 }
 
+### 강의 신청 API
+POST http://localhost:8080/lecture/apply
+Content-Type: application/json
+
+{
+  "memberId": 2,
+  "lectureId": 1,
+  "lectureItemId": 1,
+  "applyStatus": "APPLY"
+}
+
 ### 강의 조회 API
-GET http://localhost:8080/lecture/history/1
+GET http://localhost:8080/lecture/history/2
 Accept: application/json

--- a/Lecture.http
+++ b/Lecture.http
@@ -11,3 +11,7 @@ Content-Type: application/json
   "openDate": "2024-10-30",
   "isClose": false
 }
+
+### 강의 조회 API
+GET http://localhost:8080/lecture/history/1
+Accept: application/json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# [ERD 및 이유]
+
+- 수강신청 시, 실시간으로 변경이 되어야 하는 부분은 잔여좌석 수 이다.<br>
+- 강의 기본 정보와 상세 정보에 대한 변경이 없어 최소한의 락을 걸기 위해 
+Lecture 테이블을 Lecture, LectureItem, LectureInventory 로 나누었다.<br>
+ 
+
+```mermaid
+erDiagram
+    MEMBER {
+        bigint id
+        varchar(10) name
+        varchar(10) user_type
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    LECTURE_HISTORY {
+        bigint id
+        bigint member_id
+        bigint lecture_id
+        bigint lecture_item_id
+        varchar applyStatus
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    LECTURE {
+        bigint id
+        varchar(10) name
+        bigint member_id
+        varchar(10) member_name
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    LECTURE_ITEM {
+        bigint id
+        bigint lecture_id
+        int capacity
+        timestamp open_at
+        boolean is_close
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    LECTURE_INVENTORY {
+        bigint id
+        bigint lecture_id
+        bigint lecture_item_id
+        int remaining_seats
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    MEMBER ||--o{ LECTURE_HISTORY: "member_id"
+    LECTURE ||--o{ LECTURE_HISTORY: "member_id"
+    LECTURE ||--|{ LECTURE_ITEM: "lecture_id"
+    LECTURE_ITEM ||--|{ LECTURE_INVENTORY: "lecture_id"

--- a/member.http
+++ b/member.http
@@ -1,0 +1,25 @@
+### 유저 등록 API - 선생님
+POST http://localhost:8080/members
+Content-Type: application/json
+
+{
+  "name": "mangKyu",
+  "memberType": "TEACHER"
+}
+
+### 유저 조회 API
+GET http://localhost:8080/members/member/1
+Accept: application/json
+
+### 유저 등록 API - 학생
+POST http://localhost:8080/members
+Content-Type: application/json
+
+{
+  "name": "whee",
+  "memberType": "STUDENT"
+}
+
+### 유저 조회 API
+GET http://localhost:8080/members/member/2
+Accept: application/json

--- a/src/main/java/com/hhplus/cleanarchitecture/CleanArchitectureApplication.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/CleanArchitectureApplication.java
@@ -2,7 +2,9 @@ package com.hhplus.cleanarchitecture;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.*;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CleanArchitectureApplication {
 

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/common/BaseEntity.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.hhplus.cleanarchitecture.domain.common;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+import java.time.*;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -96,7 +96,11 @@ public class RegisterFacadeService {
 
         lectureHistoryService.ifApplyHistoryExistThenThrow(memberId, lectureId, lectureItemId);
 
-        lectureInventoryService.updateLectureInventoryInfo(dto);
+        LectureInventoryDto lectureInventoryDto = lectureInventoryService.updateLectureInventoryInfo(dto);
+
+        if (lectureInventoryDto.getRemainingSeats() == 0) {
+            lectureItemService.changeCloseStatus(lectureInventoryDto.getLectureItemId());
+        }
 
         lectureHistoryService.create(
                 LectureHistoryCreateDto.builder()

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -5,6 +5,7 @@ import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
 import com.hhplus.cleanarchitecture.domain.lecture.*;
 import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
@@ -14,6 +15,9 @@ import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
 import lombok.*;
 import org.springframework.stereotype.*;
 
+import java.util.*;
+import java.util.stream.*;
+
 @RequiredArgsConstructor
 @Service
 public class RegisterFacadeService {
@@ -21,6 +25,7 @@ public class RegisterFacadeService {
     private final LectureService lectureService;
     private final LectureItemService lectureItemService;
     private final LectureInventoryService lectureInventoryService;
+    private final LectureHistoryService lectureHistoryService;
 
     /**
      * 강의 기본 정보 및 잔여 정보 저장
@@ -54,5 +59,29 @@ public class RegisterFacadeService {
         );
 
         return LectureInfoDto.of(lectureDto, lectureItemDto, lectureInventoryDto);
+    }
+
+    /**
+     * 유저의 강의 신청 히스토리 조회
+     */
+    public List<LectureApplyHistoryDto> getApplyHistoryByMemberId(long memberId) {
+
+        // 히스토리 내역 조회
+        List<LectureHistory> lectureHistories = lectureHistoryService.getByMemberId(memberId);
+
+        return lectureHistories.stream()
+                .map(history -> {
+                    Long lectureId = history.getLectureId();
+                    LectureDto lectureDto = lectureService.getOrThrow(lectureId);
+
+                    Long lectureItemId = history.getLectureItemId();
+                    LectureItemDto lectureItemDto = lectureItemService.getOrThrow(lectureItemId);
+
+                    return LectureApplyHistoryDto.of(
+                            lectureDto,
+                            lectureItemDto,
+                            history.getApplyStatus()
+                    );
+                }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -17,6 +17,7 @@ import lombok.*;
 import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
@@ -105,5 +106,23 @@ public class RegisterFacadeService {
                         .applyStatus(dto.getApplyStatus())
                         .build()
         );
+    }
+
+    /**
+     * 신청 가능한 강의 목록 조회
+     */
+    public Map<LocalDate, List<LectureInfoDto>> getAvailableLectureList() {
+
+        List<LectureItemDto> availableItemDtoList = lectureItemService.getAvailable();
+
+        return availableItemDtoList.stream()
+                .collect(Collectors.groupingBy(
+                        LectureItemDto::getOpenDate,
+                        Collectors.mapping(it -> {
+                            LectureDto lectureDto = lectureService.getOrThrow(it.getLectureId());
+                            LectureInventoryDto lectureInventoryDto = lectureInventoryService.getOrThrow(it.getLectureId(), it.getId());
+                            return LectureInfoDto.of(lectureDto, it, lectureInventoryDto);
+                        }, Collectors.toList())
+                ));
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -96,6 +96,9 @@ public class RegisterFacadeService {
 
         lectureHistoryService.ifApplyHistoryExistThenThrow(memberId, lectureId, lectureItemId);
 
+        /**
+         * code review 여기에서 lectureInventory 객체를 조회할 수 없어 null이 반환되는 이슈가 발생
+         */
         LectureInventoryDto lectureInventoryDto = lectureInventoryService.updateLectureInventoryInfo(dto);
 
         if (lectureInventoryDto.getRemainingSeats() == 0) {

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -6,6 +6,7 @@ import com.hhplus.cleanarchitecture.domain.lecture.*;
 import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
 import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
@@ -13,11 +14,13 @@ import com.hhplus.cleanarchitecture.domain.lectureitem.*;
 import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
 import lombok.*;
+import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
 
 import java.util.*;
 import java.util.stream.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class RegisterFacadeService {
@@ -66,7 +69,6 @@ public class RegisterFacadeService {
      */
     public List<LectureApplyHistoryDto> getApplyHistoryByMemberId(long memberId) {
 
-        // 히스토리 내역 조회
         List<LectureHistory> lectureHistories = lectureHistoryService.getByMemberId(memberId);
 
         return lectureHistories.stream()
@@ -83,5 +85,25 @@ public class RegisterFacadeService {
                             history.getApplyStatus()
                     );
                 }).collect(Collectors.toList());
+    }
+
+    public void applyLecture(LectureApplyDto dto) {
+
+        long memberId = dto.getMemberId();
+        long lectureId = dto.getLectureId();
+        long lectureItemId = dto.getLectureItemId();
+
+        lectureHistoryService.ifApplyHistoryExistThenThrow(memberId, lectureId, lectureItemId);
+
+        lectureInventoryService.updateLectureInventoryInfo(dto);
+
+        lectureHistoryService.create(
+                LectureHistoryCreateDto.builder()
+                        .memberId(memberId)
+                        .lectureId(lectureId)
+                        .lectureItemId(lectureItemId)
+                        .applyStatus(dto.getApplyStatus())
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeService.java
@@ -1,0 +1,58 @@
+package com.hhplus.cleanarchitecture.domain.facade;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lecture.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class RegisterFacadeService {
+
+    private final LectureService lectureService;
+    private final LectureItemService lectureItemService;
+    private final LectureInventoryService lectureInventoryService;
+
+    /**
+     * 강의 기본 정보 및 잔여 정보 저장
+     */
+    public LectureInfoDto createLectureInfo(LectureInfoCreateDto dto) {
+
+        LectureDto lectureDto = lectureService.create(
+                LectureCreateDto.builder()
+                        .name(dto.getLectureName())
+                        .memberId(dto.getMemberId())
+                        .MemberName(dto.getMemberName())
+                        .build()
+        );
+
+        LectureItemDto lectureItemDto = lectureItemService.create(
+                LectureItemCreateDto.builder()
+                        .lectureId(dto.getLectureId())
+                        .capacity(dto.getCapacity())
+                        .openDate(dto.getOpenDate())
+                        .isClose(dto.getIsClose())
+                        .build()
+        );
+
+
+        LectureInventoryDto lectureInventoryDto = lectureInventoryService.create(
+                LectureInventoryCreateDto.builder()
+                        .lectureId(lectureDto.getId())
+                        .lectureItemId(lectureItemDto.getId())
+                        .remainingSeats(lectureItemDto.getCapacity())
+                        .build()
+        );
+
+        return LectureInfoDto.of(lectureDto, lectureItemDto, lectureInventoryDto);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/request/LectureApplyDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/request/LectureApplyDto.java
@@ -1,0 +1,19 @@
+
+package com.hhplus.cleanarchitecture.domain.facade.dto.request;
+
+
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureApplyDto {
+
+    long memberId;
+
+    ApplyStatus applyStatus;
+
+    Long lectureId;
+
+    Long lectureItemId;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/request/LectureInfoCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/request/LectureInfoCreateDto.java
@@ -1,0 +1,25 @@
+package com.hhplus.cleanarchitecture.domain.facade.dto.request;
+
+
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureInfoCreateDto {
+
+    String lectureName;
+
+    Long memberId;
+
+    String memberName;
+
+    Long lectureId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    Boolean isClose;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/response/LectureApplyHistoryDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/response/LectureApplyHistoryDto.java
@@ -1,0 +1,47 @@
+package com.hhplus.cleanarchitecture.domain.facade.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureApplyHistoryDto {
+
+    Long lectureId;
+
+    String lectureName;
+
+    Long memberId;
+
+    String memberName;
+
+    Long lectureItemId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    ApplyStatus applyStatus;
+
+    public static LectureApplyHistoryDto of(
+            LectureDto lectureDto,
+            LectureItemDto lectureItemDto,
+            ApplyStatus applyStatus
+    ) {
+
+        return LectureApplyHistoryDto.builder()
+                .lectureId(lectureDto.getId())
+                .lectureName(lectureDto.getName())
+                .memberId(lectureDto.getMemberId())
+                .memberName(lectureDto.getMemberName())
+                .lectureItemId(lectureItemDto.getId())
+                .capacity(lectureItemDto.getCapacity())
+                .openDate(lectureItemDto.getOpenDate())
+                .applyStatus(applyStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/response/LectureInfoDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/facade/dto/response/LectureInfoDto.java
@@ -1,0 +1,50 @@
+package com.hhplus.cleanarchitecture.domain.facade.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureInfoDto {
+
+    Long lectureId;
+
+    String lectureName;
+
+    Long memberId;
+
+    String memberName;
+
+    Long lectureItemId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    Boolean isClose;
+
+    Long lectureInventoryId;
+
+    public static LectureInfoDto of(
+            LectureDto lectureDto,
+            LectureItemDto lectureItemDto,
+            LectureInventoryDto lectureInventoryDto
+    ) {
+
+        return LectureInfoDto.builder()
+                .lectureId(lectureDto.getId())
+                .lectureName(lectureDto.getName())
+                .memberId(lectureDto.getMemberId())
+                .memberName(lectureDto.getMemberName())
+                .lectureItemId(lectureItemDto.getId())
+                .capacity(lectureItemDto.getCapacity())
+                .openDate(lectureItemDto.getOpenDate())
+                .isClose(lectureItemDto.getIsClose())
+                .lectureInventoryId(lectureInventoryDto.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/Lecture.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/Lecture.java
@@ -1,0 +1,30 @@
+package com.hhplus.cleanarchitecture.domain.lecture;
+
+import com.hhplus.cleanarchitecture.domain.common.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "lecture")
+@Entity
+public class Lecture extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "member_name")
+    private String memberName;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/Lecture.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/Lecture.java
@@ -8,6 +8,7 @@ import java.time.*;
 
 @Getter
 @Builder
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "lecture")

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.cleanarchitecture.domain.lecture;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureService.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.domain.lecture;
+
+import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import jakarta.transaction.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+
+    @Transactional
+    public LectureDto create(LectureCreateDto dto) {
+
+        Lecture lecture = lectureRepository.save(
+                Lecture.builder()
+                        .name(dto.getName())
+                        .memberId(dto.getMemberId())
+                        .memberName(dto.getMemberName())
+                        .build()
+        );
+
+        return LectureDto.of(lecture);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/LectureService.java
@@ -2,9 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lecture;
 
 import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
-import jakarta.transaction.*;
 import lombok.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @RequiredArgsConstructor
 @Service
@@ -22,6 +22,15 @@ public class LectureService {
                         .memberName(dto.getMemberName())
                         .build()
         );
+
+        return LectureDto.of(lecture);
+    }
+
+    @Transactional(readOnly = true)
+    public LectureDto getOrThrow(Long lectureId) {
+
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 강의 정보가 없습니다."));
 
         return LectureDto.of(lecture);
     }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/dto/request/LectureCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/dto/request/LectureCreateDto.java
@@ -1,0 +1,14 @@
+package com.hhplus.cleanarchitecture.domain.lecture.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureCreateDto {
+
+    String name;
+
+    Long memberId;
+
+    String MemberName;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/dto/response/LectureDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecture/dto/response/LectureDto.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.domain.lecture.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lecture.*;
+import com.hhplus.cleanarchitecture.domain.member.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureDto {
+
+    Long id;
+
+    String name;
+
+    Long memberId;
+
+    String memberName;
+
+    public static LectureDto of(Lecture lecture) {
+
+        return LectureDto.builder()
+                .id(lecture.getId())
+                .name(lecture.getName())
+                .memberId(lecture.getMemberId())
+                .memberName(lecture.getMemberName())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/ApplyStatus.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/ApplyStatus.java
@@ -1,0 +1,7 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory;
+
+public enum ApplyStatus {
+
+    APPLY,
+    CANCEL
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistory.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistory.java
@@ -1,0 +1,30 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory;
+
+import com.hhplus.cleanarchitecture.domain.common.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "lecture_history")
+@Entity
+public class LectureHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "lecture_id")
+    private Long lectureId;
+
+    @Column(name = "lecture_item_id")
+    private Long lectureItemId;
+
+    @Column(name = "apply_status")
+    private ApplyStatus applyStatus;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistory.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistory.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
+@Builder
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "lecture_history")

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface LectureHistoryRepository extends JpaRepository<LectureHistory, Long> {
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
@@ -7,4 +7,6 @@ import java.util.*;
 public interface LectureHistoryRepository extends JpaRepository<LectureHistory, Long> {
 
     List<LectureHistory> findByMemberId(long memberId);
+
+    boolean existsByMemberIdAndLectureIdAndLectureItemId(Long memberId, Long lectureId, Long lectureItemId);
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryRepository.java
@@ -2,5 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lecturehistory;
 
 import org.springframework.data.jpa.repository.*;
 
+import java.util.*;
+
 public interface LectureHistoryRepository extends JpaRepository<LectureHistory, Long> {
+
+    List<LectureHistory> findByMemberId(long memberId);
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
@@ -2,9 +2,11 @@ package com.hhplus.cleanarchitecture.domain.lecturehistory;
 
 import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.response.*;
-import jakarta.transaction.*;
 import lombok.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
 
 @RequiredArgsConstructor
 @Service
@@ -24,5 +26,11 @@ public class LectureHistoryService {
         );
 
         return LectureHistoryDto.of(lectureHistory);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LectureHistory> getByMemberId(long memberId) {
+
+        return lectureHistoryRepository.findByMemberId(memberId);
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
@@ -21,6 +21,7 @@ public class LectureHistoryService {
                 LectureHistory.builder()
                         .memberId(dto.getMemberId())
                         .lectureId(dto.getLectureId())
+                        .lectureItemId(dto.getLectureItemId())
                         .applyStatus(dto.getApplyStatus())
                         .build()
         );
@@ -32,5 +33,15 @@ public class LectureHistoryService {
     public List<LectureHistory> getByMemberId(long memberId) {
 
         return lectureHistoryRepository.findByMemberId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public void ifApplyHistoryExistThenThrow(Long memberId, Long lectureId, Long lectureItemId) {
+
+        boolean isAlreadyApplied = lectureHistoryRepository.existsByMemberIdAndLectureIdAndLectureItemId(memberId, lectureId, lectureItemId);
+
+        if (isAlreadyApplied) {
+            throw new IllegalArgumentException("이미 신청한 강의입니다.");
+        }
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryService.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory;
+
+import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.response.*;
+import jakarta.transaction.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class LectureHistoryService {
+
+    private final LectureHistoryRepository lectureHistoryRepository;
+
+    @Transactional
+    public LectureHistoryDto create(LectureHistoryCreateDto dto) {
+
+        LectureHistory lectureHistory = lectureHistoryRepository.save(
+                LectureHistory.builder()
+                        .memberId(dto.getMemberId())
+                        .lectureId(dto.getLectureId())
+                        .applyStatus(dto.getApplyStatus())
+                        .build()
+        );
+
+        return LectureHistoryDto.of(lectureHistory);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/request/LectureHistoryCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/request/LectureHistoryCreateDto.java
@@ -1,0 +1,17 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory.dto.request;
+
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureHistoryCreateDto {
+
+    String name;
+
+    Long memberId;
+
+    Long lectureId;
+
+    ApplyStatus applyStatus;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/request/LectureHistoryCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/request/LectureHistoryCreateDto.java
@@ -13,5 +13,7 @@ public class LectureHistoryCreateDto {
 
     Long lectureId;
 
+    Long lectureItemId;
+
     ApplyStatus applyStatus;
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/response/LectureHistoryDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lecturehistory/dto/response/LectureHistoryDto.java
@@ -1,0 +1,32 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lecture.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureHistoryDto {
+
+    Long id;
+
+    Long memberId;
+
+    Long lectureId;
+
+    Long lectureItemId;
+
+    ApplyStatus applyStatus;
+
+
+    public static LectureHistoryDto of(LectureHistory lectureHistory) {
+
+        return LectureHistoryDto.builder()
+                .id(lectureHistory.getId())
+                .memberId(lectureHistory.getMemberId())
+                .lectureId(lectureHistory.getLectureId())
+                .lectureItemId(lectureHistory.getLectureItemId())
+                .applyStatus(lectureHistory.getApplyStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
@@ -1,0 +1,29 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory;
+
+import com.hhplus.cleanarchitecture.domain.common.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "lecture_inventory")
+@Entity
+public class LectureInventory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "lecture_id")
+    private Long lectureId;
+
+    @Column(name = "lecture_item_id")
+    private Long lectureItemId;
+
+    @Column(name = "remaining_seats")
+    private Integer remainingSeats;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
@@ -7,6 +7,8 @@ import lombok.*;
 import java.time.*;
 
 @Getter
+@Builder
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "lecture_inventory")

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventory.java
@@ -1,10 +1,9 @@
 package com.hhplus.cleanarchitecture.domain.lectureinventory;
 
 import com.hhplus.cleanarchitecture.domain.common.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.*;
 
 @Getter
 @Builder
@@ -28,4 +27,32 @@ public class LectureInventory extends BaseEntity {
 
     @Column(name = "remaining_seats")
     private Integer remainingSeats;
+
+    /**
+     * 현재 잔여 좌석 수가 0보다 큰지 확인
+     */
+    public Boolean validateSeat() {
+        return this.remainingSeats > 0;
+    }
+
+    /**
+     * 좌석수 업데이트
+     */
+    public void updateRemainingSeats(final ApplyStatus status) {
+        if (status.equals(ApplyStatus.APPLY)) {
+            this.remainingSeats -= 1;  // 좌석을 감소시킴
+        } else {
+            this.remainingSeats += 1;  // 취소 시 좌석을 증가시킴
+        }
+    }
+
+    /**
+     * 잔여 좌석이 부족하면 예외 발생
+     */
+    public void remainingSeatsZeroThenThrow() {
+
+        if (!validateSeat()) {
+            throw new IllegalArgumentException("잔여 좌석이 부족합니다.");
+        }
+    }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
@@ -1,10 +1,18 @@
 package com.hhplus.cleanarchitecture.domain.lectureinventory;
 
+import jakarta.persistence.*;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.*;
 
 import java.util.*;
 
 public interface LectureInventoryRepository extends JpaRepository<LectureInventory, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<LectureInventory> findByLectureIdAndLectureItemId(Long lectureId, Long lectureItemId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT li FROM LectureInventory li WHERE li.lectureId = :lectureId AND li.lectureItemId = :lectureItemId")
+    Optional<LectureInventory> findByLectureIdAndLectureItemIdWithLock(@Param("lectureId") Long lectureId, @Param("lectureItemId") Long lectureItemId);
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface LectureInventoryRepository extends JpaRepository<LectureInventory, Long> {
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryRepository.java
@@ -2,5 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lectureinventory;
 
 import org.springframework.data.jpa.repository.*;
 
+import java.util.*;
+
 public interface LectureInventoryRepository extends JpaRepository<LectureInventory, Long> {
+
+    Optional<LectureInventory> findByLectureIdAndLectureItemId(Long lectureId, Long lectureItemId);
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryService.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory;
+
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import jakarta.transaction.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class LectureInventoryService {
+
+    private final LectureInventoryRepository lectureInventoryRepository;
+
+    @Transactional
+    public LectureInventoryDto create(LectureInventoryCreateDto dto) {
+
+        LectureInventory lectureInventory = lectureInventoryRepository.save(
+                LectureInventory.builder()
+                        .lectureId(dto.getLectureId())
+                        .lectureItemId(dto.getLectureItemId())
+                        .remainingSeats(dto.getRemainingSeats())
+                        .build()
+        );
+
+        return LectureInventoryDto.of(lectureInventory);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryService.java
@@ -2,9 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lectureinventory;
 
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
-import jakarta.transaction.*;
 import lombok.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @RequiredArgsConstructor
 @Service
@@ -22,6 +22,15 @@ public class LectureInventoryService {
                         .remainingSeats(dto.getRemainingSeats())
                         .build()
         );
+
+        return LectureInventoryDto.of(lectureInventory);
+    }
+
+    @Transactional(readOnly = true)
+    public LectureInventoryDto getOrThrow(Long lectureId, Long lectureItemId) {
+
+        LectureInventory lectureInventory = lectureInventoryRepository.findByLectureIdAndLectureItemId(lectureId, lectureItemId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 강의 잔여 정보가 없습니다."));
 
         return LectureInventoryDto.of(lectureInventory);
     }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/dto/request/LectureInventoryCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/dto/request/LectureInventoryCreateDto.java
@@ -1,0 +1,14 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureInventoryCreateDto {
+
+    Long lectureId;
+
+    Long lectureItemId;
+
+    Integer remainingSeats;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/dto/response/LectureInventoryDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureinventory/dto/response/LectureInventoryDto.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class LectureInventoryDto {
+
+    Long id;
+
+    Long lectureId;
+
+    Long lectureItemId;
+
+    Integer remainingSeats;
+
+
+    public static LectureInventoryDto of(LectureInventory lectureInventory) {
+
+        return LectureInventoryDto.builder()
+                .id(lectureInventory.getId())
+                .lectureId(lectureInventory.getLectureId())
+                .lectureItemId(lectureInventory.getLectureItemId())
+                .remainingSeats(lectureInventory.getRemainingSeats())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
@@ -1,0 +1,32 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem;
+
+import com.hhplus.cleanarchitecture.domain.common.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "lecture_item")
+@Entity
+public class LectureItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "lecture_id")
+    private Long lectureId;
+
+    @Column(name = "capacity")
+    private Integer capacity;
+
+    @Column(name = "open_date")
+    private LocalDate openDate;
+
+    @Column(name = "is_close")
+    private Boolean isClose;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
@@ -31,4 +31,8 @@ public class LectureItem extends BaseEntity {
 
     @Column(name = "is_close")
     private Boolean isClose;
+
+    public void chaneIsCloseTrue() {
+        this.isClose = true;
+    }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItem.java
@@ -7,6 +7,8 @@ import lombok.*;
 import java.time.*;
 
 @Getter
+@Builder
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "lecture_item")

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface LectureItemRepository extends JpaRepository<LectureItem, Long> {
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemRepository.java
@@ -2,5 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lectureitem;
 
 import org.springframework.data.jpa.repository.*;
 
+import java.util.*;
+
 public interface LectureItemRepository extends JpaRepository<LectureItem, Long> {
+
+    List<LectureItem> findAllByIsClose(boolean isClosed);
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
@@ -6,6 +6,9 @@ import lombok.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
 
+import java.util.*;
+import java.util.stream.*;
+
 @RequiredArgsConstructor
 @Service
 public class LectureItemService {
@@ -34,5 +37,18 @@ public class LectureItemService {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 강의 상세 정보가 없습니다."));
 
         return LectureItemDto.of(lectureItem);
+    }
+
+    /**
+     * 신청 가능한 강의 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<LectureItemDto> getAvailable() {
+
+        List<LectureItem> lectureItemList = lectureItemRepository.findAllByIsClose(false);
+
+        return lectureItemList.stream()
+                .map(LectureItemDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
@@ -2,9 +2,9 @@ package com.hhplus.cleanarchitecture.domain.lectureitem;
 
 import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
-import jakarta.transaction.*;
 import lombok.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @RequiredArgsConstructor
 @Service
@@ -23,6 +23,15 @@ public class LectureItemService {
                         .isClose(dto.getIsClose())
                         .build()
         );
+
+        return LectureItemDto.of(lectureItem);
+    }
+
+    @Transactional(readOnly = true)
+    public LectureItemDto getOrThrow(Long lectureItemId) {
+
+        LectureItem lectureItem = lectureItemRepository.findById(lectureItemId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 강의 상세 정보가 없습니다."));
 
         return LectureItemDto.of(lectureItem);
     }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
@@ -1,0 +1,29 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem;
+
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import jakarta.transaction.*;
+import lombok.*;
+import org.springframework.stereotype.*;
+
+@RequiredArgsConstructor
+@Service
+public class LectureItemService {
+
+    private final LectureItemRepository lectureItemRepository;
+
+    @Transactional
+    public LectureItemDto create(LectureItemCreateDto dto) {
+
+        LectureItem lectureItem = lectureItemRepository.save(
+                LectureItem.builder()
+                        .lectureId(dto.getLectureId())
+                        .capacity(dto.getCapacity())
+                        .openDate(dto.getOpenDate())
+                        .isClose(dto.getIsClose())
+                        .build()
+        );
+
+        return LectureItemDto.of(lectureItem);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemService.java
@@ -51,4 +51,14 @@ public class LectureItemService {
                 .map(LectureItemDto::of)
                 .collect(Collectors.toList());
     }
+
+    public void changeCloseStatus(Long lectureItemId) {
+
+        LectureItem lectureItem = lectureItemRepository.findById(lectureItemId)
+                .orElseThrow(() -> new IllegalStateException("특강 아이템을 찾을 수 없습니다."));
+
+        lectureItem.chaneIsCloseTrue();
+
+        lectureItemRepository.save(lectureItem);
+    }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/dto/request/LectureItemCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/dto/request/LectureItemCreateDto.java
@@ -1,0 +1,18 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem.dto.request;
+
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureItemCreateDto {
+
+    Long lectureId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    Boolean isClose;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/dto/response/LectureItemDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/lectureitem/dto/response/LectureItemDto.java
@@ -1,0 +1,34 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureItemDto {
+
+    Long id;
+
+    Long lectureId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    Boolean isClose;
+
+
+    public static LectureItemDto of(LectureItem lectureItem) {
+
+        return LectureItemDto.builder()
+                .id(lectureItem.getId())
+                .lectureId(lectureItem.getLectureId())
+                .capacity(lectureItem.getCapacity())
+                .openDate(lectureItem.getOpenDate())
+                .isClose(lectureItem.getIsClose())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/Member.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/Member.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "member")

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/Member.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/Member.java
@@ -1,0 +1,25 @@
+package com.hhplus.cleanarchitecture.domain.member;
+
+import com.hhplus.cleanarchitecture.domain.common.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "member")
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_type")
+    private MemberType memberType;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberRepository.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.hhplus.cleanarchitecture.domain.member;
+
+import org.springframework.data.jpa.repository.*;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberService.java
@@ -7,6 +7,9 @@ import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
 
+import java.util.*;
+import java.util.stream.*;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -40,5 +43,14 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 정보입니다."));
 
         return MemberDto.of(member);
+    }
+    @Transactional(readOnly = true)
+    public List<MemberDto> getByAll() {
+
+        List<Member> member = memberRepository.findAll();
+
+        return member.stream()
+                .map(MemberDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberService.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberService.java
@@ -1,0 +1,44 @@
+package com.hhplus.cleanarchitecture.domain.member;
+
+import com.hhplus.cleanarchitecture.domain.member.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.response.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 유저 등록
+     */
+    @Transactional
+    public MemberDto create(final MemberCreateDto dto) {
+
+        Member member = memberRepository.save(
+                Member.builder()
+                        .name(dto.getName())
+                        .memberType(dto.getMemberType())
+                        .build()
+        );
+
+        return MemberDto.of(member);
+    }
+
+    /**
+     * 유저 조회
+     */
+    @Transactional(readOnly = true)
+    public MemberDto get(final Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 정보입니다."));
+
+        return MemberDto.of(member);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberType.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/MemberType.java
@@ -1,0 +1,7 @@
+package com.hhplus.cleanarchitecture.domain.member;
+
+public enum MemberType {
+
+    STUDENT,
+    TEACHER
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/dto/request/MemberCreateDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/dto/request/MemberCreateDto.java
@@ -1,0 +1,13 @@
+package com.hhplus.cleanarchitecture.domain.member.dto.request;
+
+import com.hhplus.cleanarchitecture.domain.member.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class MemberCreateDto {
+
+    String name;
+
+    MemberType memberType;
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/domain/member/dto/response/MemberDto.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/domain/member/dto/response/MemberDto.java
@@ -1,0 +1,24 @@
+package com.hhplus.cleanarchitecture.domain.member.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.member.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class MemberDto {
+
+    Long id;
+
+    String name;
+
+    MemberType memberType;
+
+    public static MemberDto of(Member member) {
+
+        return MemberDto.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .memberType(member.getMemberType())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/member/MemberController.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/member/MemberController.java
@@ -1,0 +1,42 @@
+package com.hhplus.cleanarchitecture.was.member;
+
+import com.hhplus.cleanarchitecture.domain.member.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.response.*;
+import com.hhplus.cleanarchitecture.was.member.dto.request.*;
+import com.hhplus.cleanarchitecture.was.member.dto.response.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 유저 등록
+     */
+    @PostMapping
+    public MemberResponse saveMember(@RequestBody MemberCreateRequest request) {
+        log.info("name = {}, type = {}", request.getName(), request.getMemberType());
+
+        MemberDto memberDto = memberService.create(request.toReqeust());
+
+        return MemberResponse.toResponse(memberDto);
+    }
+
+    /**
+     * 유저 조회
+     */
+    @GetMapping("/member/{memberId}")
+    public MemberResponse getMember(@PathVariable("memberId") long memberId) {
+        log.info("memberId = {}", memberId);
+
+        MemberDto memberDto = memberService.get(memberId);
+
+        return MemberResponse.toResponse(memberDto);
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/member/dto/request/MemberCreateRequest.java
@@ -1,0 +1,24 @@
+package com.hhplus.cleanarchitecture.was.member.dto.request;
+
+import com.hhplus.cleanarchitecture.domain.member.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.request.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberCreateRequest {
+
+    String name;
+
+    MemberType memberType;
+
+    public MemberCreateDto toReqeust() {
+
+        return MemberCreateDto.builder()
+                .name(this.name)
+                .memberType(this.memberType)
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/member/dto/response/MemberResponse.java
@@ -1,0 +1,28 @@
+package com.hhplus.cleanarchitecture.was.member.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.member.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.response.*;
+import lombok.*;
+
+@Getter
+@Builder
+public class MemberResponse {
+
+    Long id;
+
+    String name;
+
+    MemberType memberType;
+
+    public static MemberResponse toResponse(MemberDto dto) {
+
+        if (dto == null) return null;
+
+        return MemberResponse.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .memberType(dto.getMemberType())
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.*;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.*;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +33,18 @@ public class LectureController {
 
         return ResponseEntity.ok(
                 LectureInfoResponse.toResponse(lectureInfoDto)
+        );
+    }
+
+    /**
+     * 유저가 신청한 강의 조회
+     */
+    @GetMapping("/history/{memberId}")
+    public ResponseEntity<List<LectureApplyHistoryDto>> getLectureInfo(@PathVariable("memberId") long memberId) {
+        log.info("memberId = {}", memberId);
+
+        return ResponseEntity.ok(
+                registerFacadeService.getApplyHistoryByMemberId(memberId)
         );
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
@@ -1,0 +1,36 @@
+package com.hhplus.cleanarchitecture.was.register;
+
+import com.hhplus.cleanarchitecture.domain.facade.*;
+import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
+import com.hhplus.cleanarchitecture.was.register.dto.request.*;
+import com.hhplus.cleanarchitecture.was.register.dto.response.*;
+import jakarta.validation.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/lecture")
+public class LectureController {
+
+    private final RegisterFacadeService registerFacadeService;
+
+    /**
+     * 강의 등록
+     */
+    @PostMapping
+    public ResponseEntity<LectureInfoResponse> saveLectureInfo(@Valid @RequestBody LectureInfoCreateRequest request) {
+        log.info("request = {}", request);
+
+        LectureInfoDto lectureInfoDto = registerFacadeService.createLectureInfo(
+                request.toReqeust()
+        );
+
+        return ResponseEntity.ok(
+                LectureInfoResponse.toResponse(lectureInfoDto)
+        );
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.*;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.*;
 import java.util.*;
 
 @Slf4j
@@ -58,5 +59,16 @@ public class LectureController {
         registerFacadeService.applyLecture(request.toReqeust());
 
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 신청 가능한 강의 목록 조회
+     */
+    @GetMapping("/available")
+    public ResponseEntity<Map<LocalDate, List<LectureInfoDto>>> getAvailableLecture() {
+
+        return ResponseEntity.ok(
+                registerFacadeService.getAvailableLectureList()
+        );
     }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/LectureController.java
@@ -47,4 +47,16 @@ public class LectureController {
                 registerFacadeService.getApplyHistoryByMemberId(memberId)
         );
     }
+
+    /**
+     * 강의 신청
+     */
+    @PostMapping("/apply")
+    public ResponseEntity<Void> applyLecture(@Valid @RequestBody LectureApplyRequest request) {
+        log.info("memberId = {}, status = {}", request.getMemberId(), request.getApplyStatus());
+
+        registerFacadeService.applyLecture(request.toReqeust());
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/request/LectureApplyRequest.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/request/LectureApplyRequest.java
@@ -1,0 +1,35 @@
+package com.hhplus.cleanarchitecture.was.register.dto.request;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LectureApplyRequest {
+
+    @NotNull
+    ApplyStatus applyStatus;
+
+    @NotNull
+    long memberId;
+
+    @NotNull
+    Long lectureId;
+
+    @NotNull
+    Long lectureItemId;
+
+    public LectureApplyDto toReqeust() {
+
+        return LectureApplyDto.builder()
+                .memberId(memberId)
+                .applyStatus(applyStatus)
+                .lectureId(lectureId)
+                .lectureItemId(lectureItemId)
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/request/LectureInfoCreateRequest.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/request/LectureInfoCreateRequest.java
@@ -1,0 +1,49 @@
+package com.hhplus.cleanarchitecture.was.register.dto.request;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.request.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LectureInfoCreateRequest {
+
+    @NotEmpty
+    String lectureName;
+
+    @NotNull
+    Long memberId;
+
+    @NotEmpty
+    String memberName;
+
+    @NotNull
+    Long lectureId;
+
+    @NotNull
+    Integer capacity;
+
+    @NotNull
+    LocalDate openDate;
+
+    @NotNull
+    Boolean isClose;
+
+    public LectureInfoCreateDto toReqeust() {
+
+        return LectureInfoCreateDto.builder()
+                .lectureName(lectureName)
+                .memberId(memberId)
+                .memberName(memberName)
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+    }
+}

--- a/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/response/LectureInfoResponse.java
+++ b/src/main/java/com/hhplus/cleanarchitecture/was/register/dto/response/LectureInfoResponse.java
@@ -1,0 +1,43 @@
+package com.hhplus.cleanarchitecture.was.register.dto.response;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
+import lombok.*;
+
+import java.time.*;
+
+@Getter
+@Builder
+public class LectureInfoResponse {
+
+    Long id;
+
+    String lectureName;
+
+    Long memberId;
+
+    String memberName;
+
+    Long lectureId;
+
+    Integer capacity;
+
+    LocalDate openDate;
+
+    Boolean isClose;
+
+    public static LectureInfoResponse toResponse(LectureInfoDto dto) {
+
+        if (dto == null) return null;
+
+        return LectureInfoResponse.builder()
+                .id(dto.getLectureId())
+                .lectureName(dto.getLectureName())
+                .memberId(dto.getMemberId())
+                .memberName(dto.getMemberName())
+                .lectureId(dto.getLectureItemId())
+                .capacity(dto.getCapacity())
+                .openDate(dto.getOpenDate())
+                .isClose(dto.getIsClose())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,13 +5,13 @@ spring:
   username: sa
   password:
   driver-class-name: org.h2.Driver
-jpa:
-  hibernate:
-    ddl-auto: create
-  properties:
+  jpa:
     hibernate:
-      show_sql: true
-      format_sql: true
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
 logging.level:
   org.hibernate.SQL: debug
 # org.hibernate.type: trace #??? ?? 2.x, hibernate5

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeIntegrationServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeIntegrationServiceTest.java
@@ -1,0 +1,187 @@
+
+package com.hhplus.cleanarchitecture.domain.facade;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.member.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class RegisterFacadeIntegrationServiceTest {
+
+    @Autowired
+    private RegisterFacadeService registerFacadeService;
+
+    @Autowired
+    private LectureInventoryService lectureInventoryService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("잔여 좌석까지만 정상 신청된다.")
+    @Transactional
+    void remainingEnough() {
+
+        // given
+        int threadCount = 30;
+
+        // 멤버 생성 로직 추가
+        for (int i = 1; i <= threadCount; i++) {
+            String memberName = "member" + i;
+            MemberCreateDto memberCreateDto = MemberCreateDto.builder()
+                    .name(memberName)
+                    .memberType(MemberType.STUDENT)
+                    .build();
+            memberService.create(memberCreateDto);
+        }
+
+        // when
+        List<MemberDto> memberAll = memberService.getByAll();
+
+        //then
+        assertThat(memberAll.size()).isEqualTo(threadCount);
+
+        //given
+        long teacherId = 1L;
+        String teacherName = "mangKyu";
+        long lectureId = 1L;
+        long lectureItemId = 1L;
+        long inventoryId = 1L;
+        String lectureName = "클린아키텍쳐";
+        int capacity = 30;
+        LocalDate openDate = LocalDate.now().plusDays(30);
+        boolean isClose = false;
+
+        // 초기 잔여 좌석을 30으로 설정
+        LectureInfoCreateDto lectureInfoCreateDto = LectureInfoCreateDto.builder()
+                .lectureName(lectureName)
+                .memberId(teacherId)
+                .memberName(teacherName)
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        LectureInfoDto lectureInfo = registerFacadeService.createLectureInfo(lectureInfoCreateDto);
+        assertThat(lectureInfo.getLectureName()).isEqualTo(lectureName);
+        assertThat(lectureInfo.getCapacity()).isEqualTo(capacity);
+        assertThat(lectureInfo.getLectureInventoryId()).isEqualTo(inventoryId);
+
+        // when
+        for (int i = 1; i <= threadCount; i++) {
+
+            long memberId = i;
+
+            System.out.println("memberId " + memberId + " - 수강신청 시작");
+
+            LectureApplyDto applyDto = LectureApplyDto.builder()
+                    .memberId(memberId)
+                    .lectureId(lectureId)
+                    .lectureItemId(lectureItemId)
+                    .applyStatus(ApplyStatus.APPLY)
+                    .build();
+            try {
+                registerFacadeService.applyLecture(applyDto);
+                List<LectureApplyHistoryDto> history = registerFacadeService.getApplyHistoryByMemberId(memberId);
+
+                assertThat(history.size()).isEqualTo(1);
+                assertThat(history.get(0).getLectureId()).isEqualTo(lectureId);
+                assertThat(history.get(0).getLectureItemId()).isEqualTo(lectureItemId);
+
+            } catch (Exception ignored) {
+                System.out.println("수강 신청 시 예외 발생 = " + ignored.getMessage());
+            }
+        }
+
+        // then
+        LectureInventoryDto updatedInventory = lectureInventoryService.getOrThrow(lectureId, lectureItemId);
+        assertThat(updatedInventory.getRemainingSeats()).isEqualTo(0); // 잔여 좌석이 0이어야 함
+    }
+
+    @Test
+    @DisplayName("정원 초과시 예외발생한다.")
+    @Transactional
+    void remainingOverThenThrow() {
+
+        // given
+        int threadCount = 1;
+
+        // 멤버 생성 로직 추가
+        for (int i = 1; i <= threadCount; i++) {
+            String memberName = "member" + i;
+            MemberCreateDto memberCreateDto = MemberCreateDto.builder()
+                    .name(memberName)
+                    .memberType(MemberType.STUDENT)
+                    .build();
+            memberService.create(memberCreateDto);
+        }
+
+        // when
+        List<MemberDto> memberAll = memberService.getByAll();
+
+        //then
+        assertThat(memberAll.size()).isEqualTo(threadCount);
+
+        //given
+        long teacherId = 1L;
+        String teacherName = "mangKyu";
+        long lectureId = 1L;
+        long lectureItemId = 1L;
+        long inventoryId = 1L;
+        String lectureName = "클린아키텍쳐";
+        int capacity = 0;
+        LocalDate openDate = LocalDate.now().plusDays(30);
+        boolean isClose = false;
+
+        LectureInfoCreateDto lectureInfoCreateDto = LectureInfoCreateDto.builder()
+                .lectureName(lectureName)
+                .memberId(teacherId)
+                .memberName(teacherName)
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        LectureInfoDto lectureInfo = registerFacadeService.createLectureInfo(lectureInfoCreateDto);
+        assertThat(lectureInfo.getLectureName()).isEqualTo(lectureName);
+        assertThat(lectureInfo.getCapacity()).isEqualTo(capacity);
+        assertThat(lectureInfo.getLectureInventoryId()).isEqualTo(inventoryId);
+
+        // when
+
+        Long memberId = 1L;
+        LectureApplyDto applyDto = LectureApplyDto.builder()
+                .memberId(memberId)
+                .lectureId(lectureId)
+                .lectureItemId(lectureItemId)
+                .applyStatus(ApplyStatus.APPLY)
+                .build();
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                registerFacadeService.applyLecture(applyDto)
+        );
+
+        //then
+        assertEquals("잔여 좌석이 부족합니다.", exception.getMessage());
+
+    }
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/facade/RegisterFacadeServiceTest.java
@@ -1,0 +1,107 @@
+package com.hhplus.cleanarchitecture.domain.facade;
+
+import com.hhplus.cleanarchitecture.domain.facade.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.facade.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lecture.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterFacadeServiceTest {
+
+    @Mock
+    private LectureService lectureService;
+
+    @Mock
+    private LectureInventoryService lectureInventoryService;
+
+    @Mock
+    private LectureItemService lectureItemService;
+
+    @InjectMocks
+    private RegisterFacadeService registerFacadeService;
+
+    @Test
+    @DisplayName("강의 기본 정보 및 잔여정보를 저장한다.")
+    void createLectureInfo() {
+
+        //given
+        Long lectureId = 1L;
+        String lectureName = "클린아키텍쳐";
+        Long lectureItemId = 1L;
+        Long lectureInventoryId = 1L;
+
+        LocalDate openDate = LocalDate.now().plusDays(10);
+        Boolean isClose = false;
+
+        Integer capacity = 30;
+        Integer remainingSeats = 30;
+
+        Long memberId = 1L;
+        String memberName = "김성휘";
+
+        LectureDto lectureDto = LectureDto.builder()
+                .id(lectureId)
+                .name(lectureName)
+                .memberId(memberId)
+                .memberName(memberName)
+                .build();
+
+
+        when(lectureService.create(any(LectureCreateDto.class))).thenReturn(lectureDto);
+
+        LectureItemDto lectureItemDto = LectureItemDto.builder()
+                .id(lectureItemId)
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        when(lectureItemService.create(any(LectureItemCreateDto.class))).thenReturn(lectureItemDto);
+
+        LectureInventoryDto lectureInventoryDto = LectureInventoryDto.builder()
+                .id(lectureInventoryId)
+                .lectureId(lectureId)
+                .lectureItemId(lectureItemId)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        when(lectureInventoryService.create(any(LectureInventoryCreateDto.class))).thenReturn(lectureInventoryDto);
+
+
+        LectureInfoCreateDto lectureInfoCreateDto = LectureInfoCreateDto.builder()
+                .lectureName(lectureName)
+                .memberId(memberId)
+                .memberName(memberName)
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        //when
+        LectureInfoDto lectureInfo = registerFacadeService.createLectureInfo(lectureInfoCreateDto);
+
+        //then
+        assertThat(lectureInfo.getLectureId()).isEqualTo(lectureId);
+        assertThat(lectureInfo.getLectureName()).isEqualTo(lectureName);
+        assertThat(lectureInfo.getCapacity()).isEqualTo(capacity);
+    }
+
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/lecture/LectureServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/lecture/LectureServiceTest.java
@@ -1,0 +1,55 @@
+package com.hhplus.cleanarchitecture.domain.lecture;
+
+import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectureServiceTest {
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @InjectMocks
+    private LectureService lectureService;
+
+
+    @Test
+    @DisplayName("강의를 등록한다.")
+    void createLecture() {
+
+        //given
+
+        final String lectureName = "클린아키텍쳐";
+        final Long memberId = 1L;
+        final String memberName = "김성휘";
+
+        Lecture lecture = Lecture.builder()
+                .name(lectureName)
+                .memberId(memberId)
+                .memberName(memberName)
+                .build();
+
+        when(lectureRepository.save(lecture)).thenReturn(lecture);
+//        when(lectureRepository.save(any(Lecture.class))).thenReturn(lecture);
+
+        LectureCreateDto dto = LectureCreateDto.builder()
+                .name(lectureName)
+                .memberId(memberId)
+                .MemberName(memberName)
+                .build();
+
+        //when
+        LectureDto lectureDto = lectureService.create(dto);
+
+        //then
+        assertThat(lectureDto.getName()).isEqualTo(lectureName);
+        assertThat(lectureDto.getMemberName()).isEqualTo(memberName);
+    }
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/lecturehistory/LectureHistoryServiceTest.java
@@ -1,0 +1,55 @@
+package com.hhplus.cleanarchitecture.domain.lecturehistory;
+
+import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecturehistory.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectureHistoryServiceTest {
+
+    @Mock
+    private LectureHistoryRepository lectureHistoryRepository;
+
+    @InjectMocks
+    private LectureHistoryService lectureHistoryService;
+
+
+    @Test
+    @DisplayName("강의 등록 히스토리를 등록한다.")
+    void createLectureInventory() {
+
+        //given
+
+        final Long memberId = 1L;
+        final Long lectureId = 1L;
+
+        LectureHistory lectureHistory = LectureHistory.builder()
+                .memberId(memberId)
+                .lectureId(lectureId)
+                .build();
+
+        when(lectureHistoryRepository.save(lectureHistory)).thenReturn(lectureHistory);
+//        when(lectureHistoryRepository.save(any(LectureHistory.class))).thenReturn(lectureHistory);
+
+        LectureHistoryCreateDto dto = LectureHistoryCreateDto.builder()
+                .memberId(memberId)
+                .lectureId(lectureId)
+                .build();
+
+        //when
+        LectureHistoryDto lectureHistoryDto = lectureHistoryService.create(dto);
+
+        //then
+        assertThat(lectureHistoryDto.getMemberId()).isEqualTo(memberId);
+        assertThat(lectureHistoryDto.getLectureId()).isEqualTo(lectureId);
+    }
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryServiceTest.java
@@ -1,5 +1,6 @@
 package com.hhplus.cleanarchitecture.domain.lectureinventory;
 
+import com.hhplus.cleanarchitecture.domain.lecturehistory.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
 import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
 import org.junit.jupiter.api.*;
@@ -8,6 +9,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,4 +56,125 @@ class LectureInventoryServiceTest {
         assertThat(lectureInventoryDto.getRemainingSeats()).isEqualTo(remainingSeats);
     }
 
+    @Test
+    @DisplayName("잔여수가 0 초과이면 true")
+    void validateSeatTrue() {
+
+        //given
+        Integer remainingSeats = 1;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        //when
+        Boolean validateSeat = lectureInventory.validateSeat();
+
+        //then
+        assertThat(validateSeat).isTrue();
+    }
+
+    @Test
+    @DisplayName("잔여수가 0이거나, 작으면 false")
+    void validateSeatFalse() {
+
+        //given
+        Integer remainingSeats = 0;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        //when
+        Boolean validateSeat = lectureInventory.validateSeat();
+
+        //then
+        assertThat(validateSeat).isFalse();
+    }
+
+    @Test
+    @DisplayName("신청이면 좌석수를 감소시킨다.")
+    void updateRemainingSeatsMinus() {
+
+        //given
+        ApplyStatus apply = ApplyStatus.APPLY;
+        Integer originalRemainingSeats = 10;
+        Integer resultRemainingSeats = 9;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(originalRemainingSeats)
+                .build();
+
+        //when
+        lectureInventory.updateRemainingSeats(apply);
+
+        //then
+        assertThat(lectureInventory.getRemainingSeats()).isEqualTo(resultRemainingSeats);
+    }
+
+    @Test
+    @DisplayName("취소면 좌석수를 증가시킨다.")
+    void updateRemainingSeatsPlus() {
+
+        //given
+        ApplyStatus apply = ApplyStatus.CANCEL;
+        Integer originalRemainingSeats = 10;
+        Integer resultRemainingSeats = 11;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(originalRemainingSeats)
+                .build();
+
+        //when
+        lectureInventory.updateRemainingSeats(apply);
+
+        //then
+        assertThat(lectureInventory.getRemainingSeats()).isEqualTo(resultRemainingSeats);
+    }
+
+    @Test
+    @DisplayName("잔여 좌석이 충분하면 예외 발생하지 않는다.")
+    void remainingSeatsEnough() {
+
+        //given
+        Integer remainingSeats = 1;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        //when & then
+        assertDoesNotThrow(lectureInventory::remainingSeatsZeroThenThrow);
+    }
+
+    @Test
+    @DisplayName("잔여 좌석이 부족하면 예외 발생한다.")
+    void remainingSeatsZeroThenThrow() {
+
+        //given
+        Integer remainingSeats = 0;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(1L)
+                .lectureItemId(1L)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                lectureInventory::remainingSeatsZeroThenThrow);
+
+        //then
+        assertEquals("잔여 좌석이 부족합니다.", exception.getMessage());
+    }
 }

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/lectureinventory/LectureInventoryServiceTest.java
@@ -1,0 +1,57 @@
+package com.hhplus.cleanarchitecture.domain.lectureinventory;
+
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureinventory.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectureInventoryServiceTest {
+
+    @Mock
+    private LectureInventoryRepository lectureInventoryRepository;
+
+    @InjectMocks
+    private LectureInventoryService lectureInventoryService;
+
+
+    @Test
+    @DisplayName("강의의 남은 자리 정보를 등록한다.")
+    void createLectureInventory() {
+
+        //given
+
+        final Long lectureId = 1L;
+        final Long lectureItemId = 1L;
+        final Integer remainingSeats = 30;
+
+        LectureInventory lectureInventory = LectureInventory.builder()
+                .lectureId(lectureId)
+                .lectureItemId(lectureItemId)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        when(lectureInventoryRepository.save(lectureInventory)).thenReturn(lectureInventory);
+//        when(lectureInventoryRepository.save(any(LectureInventory.class))).thenReturn(lectureInventory);
+
+        LectureInventoryCreateDto dto = LectureInventoryCreateDto.builder()
+                .lectureId(lectureId)
+                .lectureItemId(lectureItemId)
+                .remainingSeats(remainingSeats)
+                .build();
+
+        //when
+        LectureInventoryDto lectureInventoryDto = lectureInventoryService.create(dto);
+
+        //then
+        assertThat(lectureInventoryDto.getLectureId()).isEqualTo(lectureId);
+        assertThat(lectureInventoryDto.getLectureItemId()).isEqualTo(lectureItemId);
+        assertThat(lectureInventoryDto.getRemainingSeats()).isEqualTo(remainingSeats);
+    }
+
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/lectureitem/LectureItemServiceTest.java
@@ -1,0 +1,65 @@
+package com.hhplus.cleanarchitecture.domain.lectureitem;
+
+import com.hhplus.cleanarchitecture.domain.lecture.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lecture.dto.response.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.lectureitem.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectureItemServiceTest {
+
+    @Mock
+    private LectureItemRepository lectureItemRepository;
+
+    @InjectMocks
+    private LectureItemService lectureItemService;
+
+
+    @Test
+    @DisplayName("강의의 상세 정보를 등록한다.")
+    void createLectureItem() {
+
+        //given
+
+        final Long lectureId = 1L;
+        final Integer capacity = 30;
+        final LocalDate openDate = LocalDate.now().plusDays(10);
+        final Boolean isClose = false;
+
+        LectureItem lectureItem = LectureItem.builder()
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        when(lectureItemRepository.save(lectureItem)).thenReturn(lectureItem);
+//        when(lectureItemRepository.save(any(LectureItem.class))).thenReturn(lectureItem);
+
+        LectureItemCreateDto dto = LectureItemCreateDto.builder()
+                .lectureId(lectureId)
+                .capacity(capacity)
+                .openDate(openDate)
+                .isClose(isClose)
+                .build();
+
+        //when
+        LectureItemDto lectureItemDto = lectureItemService.create(dto);
+
+        //then
+        assertThat(lectureItemDto.getLectureId()).isEqualTo(lectureId);
+        assertThat(lectureItemDto.getCapacity()).isEqualTo(capacity);
+        assertThat(lectureItemDto.getIsClose()).isEqualTo(isClose);
+    }
+
+}

--- a/src/test/java/com/hhplus/cleanarchitecture/domain/member/MemberServiceTest.java
+++ b/src/test/java/com/hhplus/cleanarchitecture/domain/member/MemberServiceTest.java
@@ -1,0 +1,88 @@
+package com.hhplus.cleanarchitecture.domain.member;
+
+import com.hhplus.cleanarchitecture.domain.member.dto.request.*;
+import com.hhplus.cleanarchitecture.domain.member.dto.response.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import static com.hhplus.cleanarchitecture.domain.member.MemberType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("유저를 등록한다.")
+    void createMember() {
+
+        //given
+        final String name = "김성휘";
+        final MemberType memberType = STUDENT;
+
+        final MemberCreateDto memberCreateDto = MemberCreateDto.builder()
+                .name(name)
+                .memberType(memberType)
+                .build();
+
+        //when
+        MemberDto memberDto = memberService.create(memberCreateDto);
+
+        //then
+        assertThat(memberDto.getName()).isEqualTo(name);
+        assertThat(memberDto.getMemberType()).isEqualTo(memberType);
+    }
+
+    @Test
+    @DisplayName("유저를 조회한다.")
+    void getMember() {
+
+        //given
+        final Long memberId = 1L;
+        final String name = "김성휘";
+        final MemberType memberType = STUDENT;
+
+        final MemberCreateDto memberCreateDto = MemberCreateDto.builder()
+                .name(name)
+                .memberType(memberType)
+                .build();
+
+        memberService.create(memberCreateDto);
+
+        //when
+        MemberDto memberDto = memberService.get(memberId);
+
+        //then
+        assertThat(memberDto.getName()).isEqualTo(name);
+        assertThat(memberDto.getMemberType()).isEqualTo(memberType);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저를 조회하면 예외가 발생한다.")
+    void getMemberUnknownId() {
+
+        //given
+        final Long UnknownMemberId = 2L;
+        final String name = "김성휘";
+        final MemberType memberType = STUDENT;
+
+        final MemberCreateDto memberCreateDto = MemberCreateDto.builder()
+                .name(name)
+                .memberType(memberType)
+                .build();
+
+        memberService.create(memberCreateDto);
+
+        //when
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            memberService.get(UnknownMemberId);
+        });
+
+        //then
+        assertEquals("존재하지 않는 유저 정보입니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
# 작업내역

- 정원까지만 신청되고, 이후로는 예외 발생 통합테스트

### ERD 작성 및 이유
- 수강신청 시, 실시간으로 변경이 되어야 하는 부분은 잔여좌석 수 이다.<br>
- 강의 기본 정보와 상세 정보에 대한 변경이 없어 최소한의 락을 걸기 위해 
Lecture 테이블을 Lecture, LectureItem, LectureInventory 로 나누었다.<br>
 

```mermaid
erDiagram
    MEMBER {
        bigint id
        varchar(10) name
        varchar(10) user_type
        timestamp created_at
        timestamp updated_at
    }

    LECTURE_HISTORY {
        bigint id
        bigint member_id
        bigint lecture_id
        bigint lecture_item_id
        varchar applyStatus
        timestamp created_at
        timestamp updated_at
    }

    LECTURE {
        bigint id
        varchar(10) name
        bigint member_id
        varchar(10) member_name
        timestamp created_at
        timestamp updated_at
    }

    LECTURE_ITEM {
        bigint id
        bigint lecture_id
        int capacity
        timestamp open_at
        boolean is_close
        timestamp created_at
        timestamp updated_at
    }

    LECTURE_INVENTORY {
        bigint id
        bigint lecture_id
        bigint lecture_item_id
        int remaining_seats
        timestamp created_at
        timestamp updated_at
    }

    MEMBER ||--o{ LECTURE_HISTORY: "member_id"
    LECTURE ||--o{ LECTURE_HISTORY: "member_id"
    LECTURE ||--|{ LECTURE_ITEM: "lecture_id"
    LECTURE_ITEM ||--|{ LECTURE_INVENTORY: "lecture_id"
